### PR TITLE
move social media statement

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -30,11 +30,6 @@ const pageTitle = "Contact";
         Join the <a href="https://universalviewer.slack.com">UV Slack</a>: send an email to
         <a href="mailto:universalviewerapp@gmail.com">universalviewerapp@gmail.com</a> to request an invite.
       </p>
-    <h2>Social Media Statement</h2>
-    <p>
-      The Universal Viewer (UV) social media accounts are managed by the Steering Group and exist to promote the work of the UV and associated communities, to share examples of best practice and to promote those who contribute to, and make best use of, the UV.
-      Any social media posts will be made in good faith, and the Steering Group will consider all requests to remove posts that are reported as causing reputational damage to the community. You are welcome to report an issue to <a href="mailto:universalviewerapp@gmail.com">universalviewerapp@gmail.com</a>.
-    </p>
     </section>
   </div>
 </BaseLayout>

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -3,4 +3,10 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 const pageTitle = 'Policy';
 ---
 
-<BaseLayout pageTitle={pageTitle} />
+<BaseLayout pageTitle={pageTitle} >
+    <h2>Social Media Statement</h2>
+    <p>
+      The Universal Viewer (UV) social media accounts are managed by the Steering Group and exist to promote the work of the UV and associated communities, to share examples of best practice and to promote those who contribute to, and make best use of, the UV.
+      Any social media posts will be made in good faith, and the Steering Group will consider all requests to remove posts that are reported as causing reputational damage to the community. You are welcome to report an issue to <a href="mailto:universalviewerapp@gmail.com">universalviewerapp@gmail.com</a>.
+    </p>
+</BaseLayout>


### PR DESCRIPTION
This moves the social media statement from the Contact page to the Policies page, as discussed in https://github.com/UniversalViewer/universalviewer/issues/1679