### PR TITLE
Sets prettier + vscode config for consistent on-save formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["prettier-plugin-astro"],
   "trailingComma": "es5"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 
   // Astro formatter
   "[astro]": {
-    "editor.defaultFormatter": "astro-build.astro-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
 
   // JS / JSON / Markdown / SCSS → Prettier


### PR DESCRIPTION
Some of my commits have had a bunch of irrelevant changes because prettier wasn't running correctly, and questions about consistency have been raised in #39 

This updates prettier and vscode settings to use it as the default formatter for astro files.

I've tested this against existing pages that others have worked on recently, and prettier seemed to make the fewest (and least extreme) changes compared to the astro default formatter which mine was falling back on.

I'm not sure which editor everyone else is using however, so if everyone could check out this PR or switch your local config to see if/how it changes things then we can discuss whether to merge or use other settings. Thanks