### PR TITLE
Cy move showcase up on home

### DIFF
--- a/src/pages/cy/index.astro
+++ b/src/pages/cy/index.astro
@@ -16,144 +16,6 @@ const pageTitle = 'Home';
     </h3>
   </section>
 
-  <!-- Features -->
-  <section id="features">
-    <div class="container">
-      <h2>Nodweddion</h2>
-      <div class="features-grid">
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Zm-40-60v-80h-80v-80h80v-80h80v80h80v80h-80v80h-80Z"
-            ></path></svg
-          >
-          <h3>Gellir glosio</h3>
-          <p>
-            Closio ar ddelweddau OpenSeadragon gan ddefnyddio API delwedd IIIF.
-          </p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M240-320h480v-320H240v320Zm-80 160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm0-80h640v-480H160v480Zm0 0v-480 480Zm160-160 85-113 55 73 75-100 105 140H320Z"
-            ></path></svg
-          >
-          <h3>Gellir ymgorffori</h3>
-          <p>
-            Ymgorffori yn null YouTube gyda dolenni dwfn i dudalennau neu
-            ardaloedd closio penodol.
-          </p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="m476-80 182-480h84L924-80h-84l-43-122H603L560-80h-84ZM160-200l-56-56 202-202q-35-35-63.5-80T190-640h84q20 39 40 68t48 58q33-33 68.5-92.5T484-720H40v-80h280v-80h80v80h280v80H564q-21 72-63 148t-83 116l96 98-30 82-122-125-202 201Zm468-72h144l-72-204-72 204Z"
-            ></path></svg
-          >
-          <h3>Cyfieithadwy</h3>
-          <p>
-            Rhyngwladoleiddio'r rhyngwyneb, gyda chefnogaeth ar gyfer Saesneg,
-            Cymraeg, Swedeg a mwy.
-          </p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M686-132 444-376q-20 8-40.5 12t-43.5 4q-100 0-170-70t-70-170q0-36 10-68.5t28-61.5l146 146 72-72-146-146q29-18 61.5-28t68.5-10q100 0 170 70t70 170q0 23-4 43.5T584-516l244 242q12 12 12 29t-12 29l-84 84q-12 12-29 12t-29-12Zm29-85 27-27-256-256q18-20 26-46.5t8-53.5q0-60-38.5-104.5T386-758l74 74q12 12 12 28t-12 28L332-500q-12 12-28 12t-28-12l-74-74q9 57 53.5 95.5T360-440q26 0 52-8t47-25l256 256ZM472-488Z"
-            ></path></svg
-          >
-          <h3>Gosod dewisiadau</h3>
-          <p>
-            Mae'r UV yn hynod ffurfweddadwy gyda chyfoeth o osodiadau y gellir
-            eu haddasu.
-          </p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M423.5-743.5Q400-767 400-800t23.5-56.5Q447-880 480-880t56.5 23.5Q560-833 560-800t-23.5 56.5Q513-720 480-720t-56.5-23.5ZM360-80v-520q-60-5-122-15t-118-25l20-80q78 21 166 30.5t174 9.5q86 0 174-9.5T820-720l20 80q-56 15-118 25t-122 15v520h-80v-240h-80v240h-80Z"
-            ></path></svg
-          >
-          <h3>Hygyrch</h3>
-          <p>Yn cefnogi llywio bysellfwrdd a darllenwyr sgrin.</p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M280-160v-40h-40q-50 0-85-35t-35-85v-120H40v-80h80v-120q0-50 35-85t85-35h40v-40h80v640h-80Zm-40-120h40v-400h-40q-17 0-28.5 11.5T200-640v320q0 17 11.5 28.5T240-280Zm360 120v-160H440v-80h160v-160H440v-80h160v-160h80v40h40q50 0 85 35t35 85v120h80v80h-80v120q0 50-35 85t-85 35h-40v40h-80Zm80-120h40q17 0 28.5-11.5T760-320v-320q0-17-11.5-28.5T720-680h-40v400ZM280-480Zm400 0Z"
-            ></path></svg
-          >
-          <h3>Estynadwy</h3>
-          <p>Yn cefnogi'r gallu i weld 3D, sain, fideo a pdf.</p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
-            ></path></svg
-          >
-          <h3>Chwiliadwy</h3>
-          <p>
-            Yn cefnogi chwilio ac integreiddio gwasanaethau awtogwblhau â
-            chanlyniadau chwilio ar ffurf troshaen.
-          </p>
-        </div>
-        <div class="feature-card">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 -960 960 960"
-            width="24px"
-            fill="#1f1f1f"
-            ><path
-              d="M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v244q0 152-90.5 276.5T480-80Zm0-84q97-30 162-118.5T718-480H480v-315l-240 90v207q0 7 2 18h238v316Z"
-            ></path></svg
-          >
-          <h3>Diogeladwy</h3>
-          <p>
-            Mae'r UV yn cefnogi API Awdurdodi IIIF, felly gellir diogelu'ch
-            cynnwys gyda chyfrinair.
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <!-- Showcase -->
   <section id="showcase">
     <div class="container">
@@ -274,6 +136,144 @@ const pageTitle = 'Home';
           </div>
         </div>
       </a>
+    </div>
+  </section>
+
+  <!-- Features -->
+  <section id="features">
+    <div class="container">
+      <h2>Nodweddion</h2>
+      <div class="features-grid">
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Zm-40-60v-80h-80v-80h80v-80h80v80h80v80h-80v80h-80Z"
+            ></path></svg
+          >
+          <h3>Gellir glosio</h3>
+          <p>
+            Closio ar ddelweddau <a href="https://openseadragon.github.io/">OpenSeadragon</a> gan ddefnyddio <a href="http://iiif.io/api/image/">API delwedd IIIF</a>.
+          </p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M240-320h480v-320H240v320Zm-80 160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm0-80h640v-480H160v480Zm0 0v-480 480Zm160-160 85-113 55 73 75-100 105 140H320Z"
+            ></path></svg
+          >
+          <h3>Gellir ymgorffori</h3>
+          <p>
+            Ymgorffori yn null YouTube gyda dolenni dwfn i dudalennau neu
+            ardaloedd closio penodol.
+          </p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="m476-80 182-480h84L924-80h-84l-43-122H603L560-80h-84ZM160-200l-56-56 202-202q-35-35-63.5-80T190-640h84q20 39 40 68t48 58q33-33 68.5-92.5T484-720H40v-80h280v-80h80v80h280v80H564q-21 72-63 148t-83 116l96 98-30 82-122-125-202 201Zm468-72h144l-72-204-72 204Z"
+            ></path></svg
+          >
+          <h3>Cyfieithadwy</h3>
+          <p>
+            Rhyngwladoleiddio'r rhyngwyneb, gyda chefnogaeth ar gyfer Saesneg,
+            Cymraeg, Swedeg a mwy.
+          </p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M686-132 444-376q-20 8-40.5 12t-43.5 4q-100 0-170-70t-70-170q0-36 10-68.5t28-61.5l146 146 72-72-146-146q29-18 61.5-28t68.5-10q100 0 170 70t70 170q0 23-4 43.5T584-516l244 242q12 12 12 29t-12 29l-84 84q-12 12-29 12t-29-12Zm29-85 27-27-256-256q18-20 26-46.5t8-53.5q0-60-38.5-104.5T386-758l74 74q12 12 12 28t-12 28L332-500q-12 12-28 12t-28-12l-74-74q9 57 53.5 95.5T360-440q26 0 52-8t47-25l256 256ZM472-488Z"
+            ></path></svg
+          >
+          <h3>Gosod dewisiadau</h3>
+          <p>
+            Mae'r UV yn hynod ffurfweddadwy gyda chyfoeth o <a href="https://github.com/UniversalViewer/universalviewer/blob/dev/manual/CONFIG.md">osodiadau y gellir
+            eu haddasu</a>.
+          </p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M423.5-743.5Q400-767 400-800t23.5-56.5Q447-880 480-880t56.5 23.5Q560-833 560-800t-23.5 56.5Q513-720 480-720t-56.5-23.5ZM360-80v-520q-60-5-122-15t-118-25l20-80q78 21 166 30.5t174 9.5q86 0 174-9.5T820-720l20 80q-56 15-118 25t-122 15v520h-80v-240h-80v240h-80Z"
+            ></path></svg
+          >
+          <h3>Hygyrch</h3>
+          <p>Yn cefnogi llywio bysellfwrdd a darllenwyr sgrin.</p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M280-160v-40h-40q-50 0-85-35t-35-85v-120H40v-80h80v-120q0-50 35-85t85-35h40v-40h80v640h-80Zm-40-120h40v-400h-40q-17 0-28.5 11.5T200-640v320q0 17 11.5 28.5T240-280Zm360 120v-160H440v-80h160v-160H440v-80h160v-160h80v40h40q50 0 85 35t35 85v120h80v80h-80v120q0 50-35 85t-85 35h-40v40h-80Zm80-120h40q17 0 28.5-11.5T760-320v-320q0-17-11.5-28.5T720-680h-40v400ZM280-480Zm400 0Z"
+            ></path></svg
+          >
+          <h3>Estynadwy</h3>
+          <p>Yn cefnogi'r gallu i weld 3D, sain, fideo a pdf.</p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
+            ></path></svg
+          >
+          <h3>Chwiliadwy</h3>
+          <p>
+            Yn cefnogi <a href="http://iiif.io/api/search/">chwilio ac integreiddio gwasanaethau awtogwblhau</a> â
+            chanlyniadau chwilio ar ffurf troshaen.
+          </p>
+        </div>
+        <div class="feature-card">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="#1f1f1f"
+            ><path
+              d="M480-80q-139-35-229.5-159.5T160-516v-244l320-120 320 120v244q0 152-90.5 276.5T480-80Zm0-84q97-30 162-118.5T718-480H480v-315l-240 90v207q0 7 2 18h238v316Z"
+            ></path></svg
+          >
+          <h3>Diogeladwy</h3>
+          <p>
+            Mae'r UV yn cefnogi <a href="http://iiif.io/api/auth/">API Awdurdodi IIIF</a>, felly gellir diogelu'ch
+            cynnwys gyda chyfrinair.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
- Rearranges homepage to be in line with the changes to EN in #49 
- Adds links to the features section in CY in line with the EN version